### PR TITLE
Move away from subprocess32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-subprocess32>=3.5.0; python_version < '3.0.0'
 prometheus_client>=0.6.0
 semver >= 2.7.0


### PR DESCRIPTION
Installing subprocess32 on legacy systems may be pretty painfull, so moving to stock subprocess in python2 + our own timeout impementation