### PR TITLE
Add TLS in web interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps: &python_test
       - checkout
       - run: sudo pip install -r requirements.txt
-      - run: python -m unittest multipath_exporter_test
+      - run: python -m unittest discover -s multipath_exporter
   test_python_3_6:
     docker:
       - image: circleci/python:3.6

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Linux FC multipath exporter on Python
 
 ```sh
 pip install -r requirements.txt --no-deps
-./multipath_exporter
+./multipath_exporter/main.py
 ```
 
+## TLS
+
+The Multipath Exporter supports TLS.
+
+To use TLS, you need to pass a configuration file
+using the `--web.config.file` parameter. The format of the file is described
+[in the exporter-toolkit repository](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md).
+Supported config options: 'client_ca_file', 'cert_file' 'key_file', 'client_auth_type' in section 'tls_server_config'.

--- a/multipath_exporter/test.py
+++ b/multipath_exporter/test.py
@@ -1,5 +1,5 @@
 import unittest
-import multipath_exporter
+from multipath_exporter import main
 
 
 class TestMultipathExporter(unittest.TestCase):
@@ -11,11 +11,11 @@ class TestMultipathExporter(unittest.TestCase):
     cmd_result_123 = "1\n2\n3\n"
 
     def test_cmd_timeout_expired(self):
-        cmd_result = multipath_exporter.run_command_w_timeout(self.cmd_123, 2)
+        cmd_result = main.run_command_w_timeout(self.cmd_123, 2)
         self.assertEqual(cmd_result, None)
 
     def test_cmd_timeout(self):
-        cmd_result = multipath_exporter.run_command_w_timeout(self.cmd_123, 4)
+        cmd_result = main.run_command_w_timeout(self.cmd_123, 4)
         self.assertEqual(cmd_result, self.cmd_result_123)
 
 

--- a/multipath_exporter/web_config.py
+++ b/multipath_exporter/web_config.py
@@ -1,0 +1,40 @@
+import logging
+import sys
+import yaml
+
+class WebConfig:
+    def __init__(self, web_config_file=None):
+        self._raw_config = self._load_config_file(web_config_file)
+        self.tls_server_config = TLSServerConfig(self._raw_config)
+
+    def get_tls_config_for_http_server(self):
+        tls_settings = dict()
+        tls_settings["certfile"] = self.tls_server_config.cert_file
+        tls_settings["keyfile"] = self.tls_server_config.key_file
+        tls_settings["client_cafile"] = self.tls_server_config.client_ca_file
+        client_auth_type = self.tls_server_config.client_auth_type
+        tls_settings["client_auth_required"] = client_auth_type == "RequireAndVerifyClientCert"
+        return tls_settings
+
+    @staticmethod
+    def _load_config_file(web_config_file=None):
+        if web_config_file:
+            # test invalid yaml and path
+            try:
+                with open(web_config_file) as file:
+                    return yaml.safe_load(file)
+            except FileNotFoundError:
+                logging.error("web config file %s was not found." % web_config_file)
+                sys.exit(1)
+            except yaml.YAMLError:
+                logging.error("web config file %s is invalid YAML file." % web_config_file)
+                sys.exit(1)
+
+
+class TLSServerConfig:
+    def __init__(self, raw_config):
+        self._tls_config = raw_config.get("tls_server_config", dict()) if raw_config else dict()
+        self.cert_file = self._tls_config.get("cert_file")
+        self.key_file = self._tls_config.get("key_file")
+        self.client_auth_type = self._tls_config.get("client_auth_type", "NoClientCert")
+        self.client_ca_file = self._tls_config.get("client_ca_file")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 prometheus_client>=0.6.0
 semver >= 2.7.0
+pyyaml == 6.0.2


### PR DESCRIPTION
Introduced some TLS options in exporter web interface. New command-line argument "--web.config.file" contains some TLS config options.
The file format conforms:
https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md#web-configuration For now the config option supports 'client_ca_file', 'cert_file' 'key_file', 'client_auth_type' in section 'tls_server_config'.

Also fixed the bug when log messages are not recorded in the same exporter start.

https://github.com/newrushbolt/multipath-exporter/issues/13